### PR TITLE
Fixed ZeroDivisionError in html formatter.

### DIFF
--- a/formatters/html.rb
+++ b/formatters/html.rb
@@ -133,8 +133,8 @@ class HtmlFormatter < FormatterBase
         last = msg['media']['last_name']
         msg_body = "<div class=contact>Contact: #{first} <!--first-last-->#{last}, +#{phone}</div>"
       end
-      if msg['event'] == 'service' or msg['service'] or (message_count % timestamps_every == 0 and timestamps_every > 0)
-        if message_count % timestamps_every == 0
+      if msg['event'] == 'service' or msg['service'] or (timestamps_every > 0 and message_count % timestamps_every == 0)
+        if timestamps_every > 0 and message_count % timestamps_every == 0
           text = date_message
         else
           if get_full_name(msg['from']) != '' # Some messages have no properly filled 'from'


### PR DESCRIPTION
The value `0` for the key `timestamps_every` in the configuration of the html formatter causes a `ZeroDivisionError`

**Stacktrace:**

```
`block in format_dialog': divided by 0 (ZeroDivisionError)
	from telegram-history-dump/formatters/html.rb:63:in `reverse_each'
	from telegram-history-dump/formatters/html.rb:63:in `format_dialog'
	from telegram-history-dump.rb:291:in `block (2 levels) in <main>'
	from telegram-history-dump.rb:290:in `each'
	from telegram-history-dump.rb:290:in `block in <main>'
	from telegram-history-dump.rb:283:in `each'
	from telegram-history-dump.rb:283:in `<main>'
```


**Expected:**

The value `0` turns off printing of timestamps.
