### PR TITLE
Use the date instead of the id for msg_fresh

### DIFF
--- a/dumpers/lib/dumper_interface.rb
+++ b/dumpers/lib/dumper_interface.rb
@@ -30,7 +30,7 @@ class DumperInterface
   # This default makes sense in simple cases, override for advanced custom logic
   def msg_fresh?(msg, progress)
     # msg: Hash, progress: DumpProgress
-    !progress.last_id || msg['id'] > progress.last_id
+    !progress.last_date || msg['date'] > progress.last_date
   end
 
   # Will be called for each message to dump (from newest to oldest)


### PR DESCRIPTION
The previous check whether the id of the message is greater than the
last progress id always returned false, even when that should not
be the case. This works if you use the date of the message and
last_date of the progress instead.

I don't know if I've missed something in the config. But using this change I can now use the incremental backup feature. Is this currently working for anyone else? I used the latest telegram-cli version from git.