### PR TITLE
Add loop_video option to the html formatter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,7 @@
   #    paginate: 1500, # messages per page
   #    use_utc_time: false,
   #    timestamps_every: 50, # messages
+  #    loop_video: true, # loop and autoplay videos
   #  },
   }
 

--- a/formatters/html.rb
+++ b/formatters/html.rb
@@ -119,7 +119,11 @@ class HtmlFormatter < FormatterBase
             msg_body = "<a href='#{relative_url}'>Download #{extension} file</a>"
           end
           if filetype == 'audio' or filetype == 'video'
-            msg_body = "<#{filetype} src='#{relative_url}' controls>Your browser does not support inline playback.</#{filetype}><br><a href='#{relative_url}'>Download #{filetype}</a>"
+            msg_body = "<#{filetype} src='#{relative_url}' controls"
+            if $config['formatters']['html']['loop_video'] && filetype == 'video'
+              msg_body += " loop autoplay muted"
+            end
+            msg_body += ">Your browser does not support inline playback.</#{filetype}><br><a href='#{relative_url}'>Download #{filetype}</a>"
           end
         end
         author += '<br>' if author != '' # In file messages (unlike text messages), author is followed by a new line


### PR DESCRIPTION
When set to true this option will add autoplay and loop options to video
tags. That way video gifs will be displayed the same as in the telegram
client.