### PR TITLE
Allow to increase the number of dialogs to backup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,9 @@
   # is built from their test branch (feature tested with tg revision c69f2a2)
   backup_channels: null
 
+  # By default telegram-cli return only the first 100 dialogs.
+  # If you want or have more dialogs to backup, increase this value.
+  maximum_dialogs: 100
 
   ## Output options ##
 

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -239,7 +239,7 @@ end
 
 connect_socket
 
-dialogs = exec_tg_command('dialog_list')
+dialogs = exec_tg_command('dialog_list', $config['maximum_dialogs'])
 channels = $config['backup_channels'] ?
   exec_tg_command('channel_list') : []
 raise 'Expected array' unless dialogs.is_a?(Array) && channels.is_a?(Array)


### PR DESCRIPTION
If you have more than 100 conversations, telegram-cli will only return the first 100, so not everything is backuped.

This add an option in the config file to retrieve more conversation :)