### PR TITLE
Add option for unix-socket in config.yml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,15 @@
 
   ## Technical options ##
 
+  # Use a unix socket to communicate with telegram-cli
+  # Should match the path passed to telegram-cli with the -S option
+  #
+  # NB: Setting tg_sock to some not false value will cause the script
+  # to ignore the next options about TCP connection
+
+  # tg_sock: "/var/run/telegram.sock"
+  tg_sock: null
+
   # Address of the machine you are running telegram-cli on
   # If this is not localhost telegram-cli must be invoked with --accept-any-tcp
   tg_host: 'localhost'

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -22,9 +22,15 @@ cli_opts = CliParser.parse(ARGV)
 
 def connect_socket
   return if defined?($sock) && $sock
-  $log.info('Attaching to telegram-cli control socket at %s:%d' %
-              [$config['tg_host'], $config['tg_port']])
-  $sock = TCPSocket.open($config['tg_host'], $config['tg_port'])
+
+  if $config['tg_sock']
+    $log.info('Attaching to telegram-cli control socket at /var/run/telegram.sock')
+    $sock = UNIXSocket.new($config['tg_sock'])
+  else
+    $log.info('Attaching to telegram-cli control socket at %s:%d' %
+                [$config['tg_host'], $config['tg_port']])
+    $sock = TCPSocket.open($config['tg_host'], $config['tg_port'])
+  end
 end
 
 def disconnect_socket


### PR DESCRIPTION
Add configuration option to allow using unix-socket to connect
with the daemonized telegram-cli (i.e.  using the command `telegram-cli -d -S
/var/run/telegram.sock`).

If null value is set for the socket pack the TCP connection is used.
If a path is set for the socket TCP connection options are ignored.

WHY: With unix-socket running telegram-cli as a daemon is more secure.
With tpc connection the interface to user personal data served by telegram-cli
is accessible system wide.
With unix-socket user can set specific privileges on the socket
and thus restrict the access to that interface.