### PR TITLE
Improvements when downloading media / handling responses

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -123,9 +123,8 @@
   chunk_retry: 3
 
   # Time in seconds to wait before considering a download stuck (0 = infinite)
-  # This setting is not very useful at the moment, it just skips to the next
-  # dialog if downloading a media file takes too long
-  media_timeout: 0
+  # After this time the script skips to the next message
+  media_timeout: 100
 
 
   ## Advanced behavior settings ##

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -86,7 +86,12 @@ def dump_dialog(dialog)
           msg_chunk = exec_tg_command('history', dialog['print_name'],
                                       $config['chunk_size'], cur_offset)
         end
-        break
+        if msg_chunk.is_a?(Array)
+          break
+        end
+        $log.error('telegram-cli returned a non array chunk, retrying... (%d/%d)' % [
+          retry_count += 1, $config['chunk_retry']
+        ])
       rescue Timeout::Error
         $log.error('Timeout, retrying... (%d/%d)' % [
           retry_count += 1, $config['chunk_retry']

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -160,10 +160,12 @@ def process_media(dialog, msg)
         response = exec_tg_command('load_' + media_type, msg['id'])
       rescue StandardError => e
         $log.error('Failed to download media file: %s' % e)
-        return
       end
     end
     filename = case
+      when response.nil? || !response.is_a?(Hash)
+        $log.error('Wrong response on media download for message id %s' % msg['id'])
+        nil
       when $config['copy_media']
         filename = File.basename(response['result'])
         destination = File.join(get_media_dir(dialog), fix_media_ext(filename))
@@ -177,7 +179,7 @@ def process_media(dialog, msg)
     rescue StandardError => e
       $log.error('Failed to delete media file: %s' % e)
     end
-    msg['media']['file'] = filename if filename
+    msg['media']['file'] = filename
   end
 end
 

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -253,6 +253,7 @@ $config = YAML.load_file(
   cli_opts.cfgfile ||
   File.expand_path('../config.yaml', __FILE__)
 )
+STDOUT.sync = true
 $log = Logger.new(STDOUT)
 
 if $config['track_progress'] && system_big_endian?

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -89,11 +89,11 @@ def dump_dialog(dialog)
         if msg_chunk.is_a?(Array)
           break
         end
-        $log.error('telegram-cli returned a non array chunk, retrying... (%d/%d)' % [
+        $log.warn('telegram-cli returned a non array chunk, retrying... (%d/%d)' % [
           retry_count += 1, $config['chunk_retry']
         ])
       rescue Timeout::Error
-        $log.error('Timeout, retrying... (%d/%d)' % [
+        $log.warn('Timeout, retrying... (%d/%d)' % [
           retry_count += 1, $config['chunk_retry']
         ])
       end
@@ -165,7 +165,8 @@ def process_media(dialog, msg)
         response = exec_tg_command('load_' + media_type, msg['id'])
       end
     rescue StandardError => e
-      $log.error('Failed to download media file: %s' % e)
+      # This is a warning because we're going to log an error afterwards
+      $log.warn('Failed to download media file: %s' % e)
     end
     filename = case
       when response.nil? || !response.is_a?(Hash)

--- a/telegram-history-dump.rb
+++ b/telegram-history-dump.rb
@@ -160,12 +160,12 @@ def process_media(dialog, msg)
     next unless $config['download_media'][media_type]
     next unless msg['media']['type'] == media_type
     response = nil
-    Timeout::timeout($config['media_timeout']) do
-      begin
+    begin
+      Timeout::timeout($config['media_timeout']) do
         response = exec_tg_command('load_' + media_type, msg['id'])
-      rescue StandardError => e
-        $log.error('Failed to download media file: %s' % e)
       end
+    rescue StandardError => e
+      $log.error('Failed to download media file: %s' % e)
     end
     filename = case
       when response.nil? || !response.is_a?(Hash)


### PR DESCRIPTION
Reimplementation of #61. I reviewed the changes, looked at each note. This contains additional changes for convenience. **Summary (look at each commit's description for details):**

 - [X] https://github.com/tvdstaaij/telegram-history-dump/commit/6a28e0de3e6ab14cf46c79fa79479679bdf6143e: Little fix for code that caused media timeouts to abort the whole chat.

 - [X] https://github.com/tvdstaaij/telegram-history-dump/commit/b7ace13f5a327b10768489b5e192ef7be98418be: If media download fails, `media` attribute will be set to `null` to explicitely indicate it in the output.

 - [X] https://github.com/tvdstaaij/telegram-history-dump/commit/b7ace13f5a327b10768489b5e192ef7be98418be: Detect invalid media responses from `telegram-cli` instead of crashing.

 - [x] https://github.com/tvdstaaij/telegram-history-dump/commit/ec7bb958a062a41470c531ea2bcf80c56feac8ed: Detect invalid chunks returned by `telegram-cli` instead of crashing.

**Minor changes** (not affecting behaviour):

 - [X] https://github.com/tvdstaaij/telegram-history-dump/commit/eb1a091a30b6192e795e19805c7492d45236fa28: This allows piping `telegram-history-dump` to another program.

 - [X] https://github.com/tvdstaaij/telegram-history-dump/commit/a48a2eb6f7052591139ad5c3aa891fdeddf51c79: Turn some non-fatal errors into warnings.

 - [X] https://github.com/tvdstaaij/telegram-history-dump/commit/6e655f8f0ec2e31b15275518349f9744f5c63148: Change default config to enable media download timeout, now that it works as intended.

I'm aware this is quite a bunch of changes; I've tried to keep them simple and minimal but I'm open to changing or dropping some if you're not okay with them.