### PR TITLE
Added . to characters to replace (bad_characters)

### DIFF
--- a/lib/util.rb
+++ b/lib/util.rb
@@ -2,7 +2,7 @@ require 'pathname'
 require_relative './dump_prepender'
 
 def get_safe_name(name)
-  bad_characters = /([\/\\<>:"|?*]|[^\u0021-\uFFFF])/
+  bad_characters = /([\/\\<>:"|?*.]|[^\u0021-\uFFFF])/
   clean_name = name.gsub(bad_characters, $config['character_substitute'])
   truncate_to_bytesize(clean_name, 220, '_[truncated]')
 end


### PR DESCRIPTION
Period at end of chat name causes issues, this solves that but also will replace them throughout the entire name. This is a somewhat harmless side effect.

Solves #107 