### PR TITLE
Fix up pisg output ordering of messages.

### DIFF
--- a/formatters/pisg.rb
+++ b/formatters/pisg.rb
@@ -55,7 +55,7 @@ class PisgFormatter < DailyFileFormatter
     @oldest_message_date ||= Time.at(message['date'])
     lines = message['text'].to_s.split("\n")
     lines.push('') if lines.empty?
-    lines.reverse_each do |message_line|
+    lines.each_entry do |message_line|
       dump_message_line(message, message_line, output_stream)
     end
   end


### PR DESCRIPTION
The pisg formatter splits a multiline message into individual lines but in reverse order. This change fixes up the order of the output

Example:
1. One
2. Two
3. Three

would have been generated as

3. Three
2. Two
1. One

previously